### PR TITLE
Allow underscores in variable values

### DIFF
--- a/doc/zonefile.treetop
+++ b/doc/zonefile.treetop
@@ -33,7 +33,7 @@ grammar Zonefile
   end
 
   rule variable
-    "$" name:([a-zA-Z0-9]+) space value:([a-zA-Z0-9\.\-]+) space? comment? {
+    "$" name:([a-zA-Z0-9]+) space value:([a-zA-Z0-9\.\-_]+) space? comment? {
       def to_s
         "$#{name.text_value.to_s} #{value.text_value.to_s}"
       end

--- a/lib/dns/zonefile/parser.rb
+++ b/lib/dns/zonefile/parser.rb
@@ -219,7 +219,7 @@ module DNS
             if r4
               s5, i5 = [], index
               loop do
-                if has_terminal?('\G[a-zA-Z0-9\\.\\-]', true, index)
+                if has_terminal?('\G[a-zA-Z0-9\\.\\-_]', true, index)
                   r6 = true
                   @index += 1
                 else


### PR DESCRIPTION
Allowing underscores in variable values is needed to allow for example $ORIGIN to point to names containing underscores.