### PR TITLE
Accept quoted multiline TXT fields

### DIFF
--- a/doc/zonefile.treetop
+++ b/doc/zonefile.treetop
@@ -397,10 +397,35 @@ grammar Zonefile
   end
   
   rule txt_data
-    '"'? ('\\"' / !'"' [^\n\r])* '"'? (space '"' ('\\"' / !'"' [^\n\r])* '"')* {
+    txt_string (space txt_data)* {
       def to_s
         text_value
       end
     }
   end
+
+  rule txt_string
+    (quoted_string / unquoted_string) {
+      def to_s
+        text_value
+      end
+    }
+  end
+
+  rule quoted_string
+    ( '"' ( '\"' / [^"] )* '"') {
+      def to_s
+        text_value
+      end
+    }
+  end
+
+  rule unquoted_string
+    [a-zA-Z0-9]+ {
+      def to_s
+        text_value
+      end
+    }
+  end
+
 end

--- a/lib/dns/zonefile/parser.rb
+++ b/lib/dns/zonefile/parser.rb
@@ -55,7 +55,7 @@ module DNS
         if node_cache[:zone].has_key?(index)
           cached = node_cache[:zone][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:zone][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -67,14 +67,17 @@ module DNS
           i2 = index
           r3 = _nt_variable
           if r3
+            r3 = SyntaxNode.new(input, (index-1)...index) if r3 == true
             r2 = r3
           else
             r4 = _nt_space_or_break
             if r4
+              r4 = SyntaxNode.new(input, (index-1)...index) if r4 == true
               r2 = r4
             else
               r5 = _nt_comment
               if r5
+                r5 = SyntaxNode.new(input, (index-1)...index) if r5 == true
                 r2 = r5
               else
                 @index = i2
@@ -99,22 +102,27 @@ module DNS
               i8 = index
               r9 = _nt_resource_record
               if r9
+                r9 = SyntaxNode.new(input, (index-1)...index) if r9 == true
                 r8 = r9
               else
                 r10 = _nt_variable
                 if r10
+                  r10 = SyntaxNode.new(input, (index-1)...index) if r10 == true
                   r8 = r10
                 else
                   r11 = _nt_comment
                   if r11
+                    r11 = SyntaxNode.new(input, (index-1)...index) if r11 == true
                     r8 = r11
                   else
                     r12 = _nt_space
                     if r12
+                      r12 = SyntaxNode.new(input, (index-1)...index) if r12 == true
                       r8 = r12
                     else
                       r13 = _nt_linebreak
                       if r13
+                        r13 = SyntaxNode.new(input, (index-1)...index) if r13 == true
                         r8 = r13
                       else
                         @index = i8
@@ -176,28 +184,29 @@ module DNS
         if node_cache[:variable].has_key?(index)
           cached = node_cache[:variable][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:variable][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
         end
 
         i0, s0 = index, []
-        if has_terminal?("$", false, index)
-          r1 = instantiate_node(SyntaxNode,input, index...(index + 1))
-          @index += 1
+        if (match_len = has_terminal?("$", false, index))
+          r1 = true
+          @index += match_len
         else
-          terminal_parse_failure("$")
+          terminal_parse_failure('"$"')
           r1 = nil
         end
         s0 << r1
         if r1
           s2, i2 = [], index
           loop do
-            if has_terminal?('\G[a-zA-Z0-9]', true, index)
+            if has_terminal?(@regexps[gr = '\A[a-zA-Z0-9]'] ||= Regexp.new(gr), :regexp, index)
               r3 = true
               @index += 1
             else
+              terminal_parse_failure('[a-zA-Z0-9]')
               r3 = nil
             end
             if r3
@@ -219,10 +228,11 @@ module DNS
             if r4
               s5, i5 = [], index
               loop do
-                if has_terminal?('\G[a-zA-Z0-9\\.\\-]', true, index)
+                if has_terminal?(@regexps[gr = '\A[a-zA-Z0-9\\.\\-]'] ||= Regexp.new(gr), :regexp, index)
                   r6 = true
                   @index += 1
                 else
+                  terminal_parse_failure('[a-zA-Z0-9\\.\\-]')
                   r6 = nil
                 end
                 if r6
@@ -361,7 +371,7 @@ module DNS
         if node_cache[:soa].has_key?(index)
           cached = node_cache[:soa][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:soa][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -380,11 +390,11 @@ module DNS
               r4 = _nt_klass
               s0 << r4
               if r4
-                if has_terminal?("SOA", false, index)
-                  r5 = instantiate_node(SyntaxNode,input, index...(index + 3))
-                  @index += 3
+                if (match_len = has_terminal?("SOA", false, index))
+                  r5 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                  @index += match_len
                 else
-                  terminal_parse_failure("SOA")
+                  terminal_parse_failure('"SOA"')
                   r5 = nil
                 end
                 s0 << r5
@@ -404,11 +414,11 @@ module DNS
                           r10 = _nt_space
                           s0 << r10
                           if r10
-                            if has_terminal?("(", false, index)
-                              r12 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                              @index += 1
+                            if (match_len = has_terminal?("(", false, index))
+                              r12 = true
+                              @index += match_len
                             else
-                              terminal_parse_failure("(")
+                              terminal_parse_failure('"("')
                               r12 = nil
                             end
                             if r12
@@ -469,11 +479,11 @@ module DNS
                                                   r24 = instantiate_node(SyntaxNode,input, i24...index, s24)
                                                   s0 << r24
                                                   if r24
-                                                    if has_terminal?(")", false, index)
-                                                      r27 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                                                      @index += 1
+                                                    if (match_len = has_terminal?(")", false, index))
+                                                      r27 = true
+                                                      @index += match_len
                                                     else
-                                                      terminal_parse_failure(")")
+                                                      terminal_parse_failure('")"')
                                                       r27 = nil
                                                     end
                                                     if r27
@@ -567,7 +577,7 @@ module DNS
         if node_cache[:resource_record].has_key?(index)
           cached = node_cache[:resource_record][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:resource_record][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -577,46 +587,57 @@ module DNS
         i1 = index
         r2 = _nt_a_record
         if r2
+          r2 = SyntaxNode.new(input, (index-1)...index) if r2 == true
           r1 = r2
         else
           r3 = _nt_aaaa_record
           if r3
+            r3 = SyntaxNode.new(input, (index-1)...index) if r3 == true
             r1 = r3
           else
             r4 = _nt_cname_record
             if r4
+              r4 = SyntaxNode.new(input, (index-1)...index) if r4 == true
               r1 = r4
             else
               r5 = _nt_mx_record
               if r5
+                r5 = SyntaxNode.new(input, (index-1)...index) if r5 == true
                 r1 = r5
               else
                 r6 = _nt_naptr_record
                 if r6
+                  r6 = SyntaxNode.new(input, (index-1)...index) if r6 == true
                   r1 = r6
                 else
                   r7 = _nt_ns_record
                   if r7
+                    r7 = SyntaxNode.new(input, (index-1)...index) if r7 == true
                     r1 = r7
                   else
                     r8 = _nt_ptr_record
                     if r8
+                      r8 = SyntaxNode.new(input, (index-1)...index) if r8 == true
                       r1 = r8
                     else
                       r9 = _nt_srv_record
                       if r9
+                        r9 = SyntaxNode.new(input, (index-1)...index) if r9 == true
                         r1 = r9
                       else
                         r10 = _nt_spf_record
                         if r10
+                          r10 = SyntaxNode.new(input, (index-1)...index) if r10 == true
                           r1 = r10
                         else
                           r11 = _nt_txt_record
                           if r11
+                            r11 = SyntaxNode.new(input, (index-1)...index) if r11 == true
                             r1 = r11
                           else
                             r12 = _nt_soa_record
                             if r12
+                              r12 = SyntaxNode.new(input, (index-1)...index) if r12 == true
                               r1 = r12
                             else
                               @index = i1
@@ -710,7 +731,7 @@ module DNS
         if node_cache[:a_record].has_key?(index)
           cached = node_cache[:a_record][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:a_record][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -729,11 +750,11 @@ module DNS
               r4 = _nt_klass
               s0 << r4
               if r4
-                if has_terminal?("A", false, index)
-                  r5 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                  @index += 1
+                if (match_len = has_terminal?("A", false, index))
+                  r5 = true
+                  @index += match_len
                 else
-                  terminal_parse_failure("A")
+                  terminal_parse_failure('"A"')
                   r5 = nil
                 end
                 s0 << r5
@@ -777,7 +798,7 @@ module DNS
         if node_cache[:ip_address].has_key?(index)
           cached = node_cache[:ip_address][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:ip_address][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -786,10 +807,11 @@ module DNS
         i0, s0 = index, []
         s1, i1 = [], index
         loop do
-          if has_terminal?('\G[\\d]', true, index)
+          if has_terminal?(@regexps[gr = '\A[\\d]'] ||= Regexp.new(gr), :regexp, index)
             r2 = true
             @index += 1
           else
+            terminal_parse_failure('[\\d]')
             r2 = nil
           end
           if r2
@@ -806,21 +828,22 @@ module DNS
         end
         s0 << r1
         if r1
-          if has_terminal?(".", false, index)
-            r3 = instantiate_node(SyntaxNode,input, index...(index + 1))
-            @index += 1
+          if (match_len = has_terminal?(".", false, index))
+            r3 = true
+            @index += match_len
           else
-            terminal_parse_failure(".")
+            terminal_parse_failure('"."')
             r3 = nil
           end
           s0 << r3
           if r3
             s4, i4 = [], index
             loop do
-              if has_terminal?('\G[\\d]', true, index)
+              if has_terminal?(@regexps[gr = '\A[\\d]'] ||= Regexp.new(gr), :regexp, index)
                 r5 = true
                 @index += 1
               else
+                terminal_parse_failure('[\\d]')
                 r5 = nil
               end
               if r5
@@ -837,21 +860,22 @@ module DNS
             end
             s0 << r4
             if r4
-              if has_terminal?(".", false, index)
-                r6 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                @index += 1
+              if (match_len = has_terminal?(".", false, index))
+                r6 = true
+                @index += match_len
               else
-                terminal_parse_failure(".")
+                terminal_parse_failure('"."')
                 r6 = nil
               end
               s0 << r6
               if r6
                 s7, i7 = [], index
                 loop do
-                  if has_terminal?('\G[\\d]', true, index)
+                  if has_terminal?(@regexps[gr = '\A[\\d]'] ||= Regexp.new(gr), :regexp, index)
                     r8 = true
                     @index += 1
                   else
+                    terminal_parse_failure('[\\d]')
                     r8 = nil
                   end
                   if r8
@@ -868,21 +892,22 @@ module DNS
                 end
                 s0 << r7
                 if r7
-                  if has_terminal?(".", false, index)
-                    r9 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                    @index += 1
+                  if (match_len = has_terminal?(".", false, index))
+                    r9 = true
+                    @index += match_len
                   else
-                    terminal_parse_failure(".")
+                    terminal_parse_failure('"."')
                     r9 = nil
                   end
                   s0 << r9
                   if r9
                     s10, i10 = [], index
                     loop do
-                      if has_terminal?('\G[\\d]', true, index)
+                      if has_terminal?(@regexps[gr = '\A[\\d]'] ||= Regexp.new(gr), :regexp, index)
                         r11 = true
                         @index += 1
                       else
+                        terminal_parse_failure('[\\d]')
                         r11 = nil
                       end
                       if r11
@@ -955,7 +980,7 @@ module DNS
         if node_cache[:aaaa_record].has_key?(index)
           cached = node_cache[:aaaa_record][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:aaaa_record][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -974,11 +999,11 @@ module DNS
               r4 = _nt_klass
               s0 << r4
               if r4
-                if has_terminal?("AAAA", false, index)
-                  r5 = instantiate_node(SyntaxNode,input, index...(index + 4))
-                  @index += 4
+                if (match_len = has_terminal?("AAAA", false, index))
+                  r5 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                  @index += match_len
                 else
-                  terminal_parse_failure("AAAA")
+                  terminal_parse_failure('"AAAA"')
                   r5 = nil
                 end
                 s0 << r5
@@ -1019,7 +1044,7 @@ module DNS
         if node_cache[:ip6_address].has_key?(index)
           cached = node_cache[:ip6_address][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:ip6_address][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -1027,10 +1052,11 @@ module DNS
 
         s0, i0 = [], index
         loop do
-          if has_terminal?('\G[\\da-fA-F:.]', true, index)
+          if has_terminal?(@regexps[gr = '\A[\\da-fA-F:.]'] ||= Regexp.new(gr), :regexp, index)
             r1 = true
             @index += 1
           else
+            terminal_parse_failure('[\\da-fA-F:.]')
             r1 = nil
           end
           if r1
@@ -1046,6 +1072,9 @@ module DNS
           @index = i0
           r0 = nil
         else
+          if s0.size < 39
+            terminal_failures.pop
+          end
           r0 = instantiate_node(SyntaxNode,input, i0...index, s0)
           r0.extend(Ip6Address0)
         end
@@ -1162,7 +1191,7 @@ module DNS
         if node_cache[:cname_record].has_key?(index)
           cached = node_cache[:cname_record][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:cname_record][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -1182,11 +1211,11 @@ module DNS
               r5 = _nt_klass
               s1 << r5
               if r5
-                if has_terminal?("CNAME", false, index)
-                  r6 = instantiate_node(SyntaxNode,input, index...(index + 5))
-                  @index += 5
+                if (match_len = has_terminal?("CNAME", false, index))
+                  r6 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                  @index += match_len
                 else
-                  terminal_parse_failure("CNAME")
+                  terminal_parse_failure('"CNAME"')
                   r6 = nil
                 end
                 s1 << r6
@@ -1210,6 +1239,7 @@ module DNS
           r1 = nil
         end
         if r1
+          r1 = SyntaxNode.new(input, (index-1)...index) if r1 == true
           r0 = r1
           r0.extend(CnameRecord4)
         else
@@ -1226,11 +1256,11 @@ module DNS
                 r13 = _nt_ttl
                 s9 << r13
                 if r13
-                  if has_terminal?("CNAME", false, index)
-                    r14 = instantiate_node(SyntaxNode,input, index...(index + 5))
-                    @index += 5
+                  if (match_len = has_terminal?("CNAME", false, index))
+                    r14 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                    @index += match_len
                   else
-                    terminal_parse_failure("CNAME")
+                    terminal_parse_failure('"CNAME"')
                     r14 = nil
                   end
                   s9 << r14
@@ -1254,6 +1284,7 @@ module DNS
             r9 = nil
           end
           if r9
+            r9 = SyntaxNode.new(input, (index-1)...index) if r9 == true
             r0 = r9
             r0.extend(CnameRecord4)
           else
@@ -1267,11 +1298,11 @@ module DNS
                 r20 = _nt_ttl
                 s17 << r20
                 if r20
-                  if has_terminal?("CNAME", false, index)
-                    r21 = instantiate_node(SyntaxNode,input, index...(index + 5))
-                    @index += 5
+                  if (match_len = has_terminal?("CNAME", false, index))
+                    r21 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                    @index += match_len
                   else
-                    terminal_parse_failure("CNAME")
+                    terminal_parse_failure('"CNAME"')
                     r21 = nil
                   end
                   s17 << r21
@@ -1294,6 +1325,7 @@ module DNS
               r17 = nil
             end
             if r17
+              r17 = SyntaxNode.new(input, (index-1)...index) if r17 == true
               r0 = r17
               r0.extend(CnameRecord4)
             else
@@ -1307,11 +1339,11 @@ module DNS
                   r27 = _nt_klass
                   s24 << r27
                   if r27
-                    if has_terminal?("CNAME", false, index)
-                      r28 = instantiate_node(SyntaxNode,input, index...(index + 5))
-                      @index += 5
+                    if (match_len = has_terminal?("CNAME", false, index))
+                      r28 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                      @index += match_len
                     else
-                      terminal_parse_failure("CNAME")
+                      terminal_parse_failure('"CNAME"')
                       r28 = nil
                     end
                     s24 << r28
@@ -1334,6 +1366,7 @@ module DNS
                 r24 = nil
               end
               if r24
+                r24 = SyntaxNode.new(input, (index-1)...index) if r24 == true
                 r0 = r24
                 r0.extend(CnameRecord4)
               else
@@ -1394,7 +1427,7 @@ module DNS
         if node_cache[:mx_record].has_key?(index)
           cached = node_cache[:mx_record][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:mx_record][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -1413,11 +1446,11 @@ module DNS
               r4 = _nt_klass
               s0 << r4
               if r4
-                if has_terminal?("MX", false, index)
-                  r5 = instantiate_node(SyntaxNode,input, index...(index + 2))
-                  @index += 2
+                if (match_len = has_terminal?("MX", false, index))
+                  r5 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                  @index += match_len
                 else
-                  terminal_parse_failure("MX")
+                  terminal_parse_failure('"MX"')
                   r5 = nil
                 end
                 s0 << r5
@@ -1492,7 +1525,7 @@ module DNS
         if node_cache[:naptr_record].has_key?(index)
           cached = node_cache[:naptr_record][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:naptr_record][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -1511,11 +1544,11 @@ module DNS
               r4 = _nt_klass
               s0 << r4
               if r4
-                if has_terminal?("NAPTR", false, index)
-                  r5 = instantiate_node(SyntaxNode,input, index...(index + 5))
-                  @index += 5
+                if (match_len = has_terminal?("NAPTR", false, index))
+                  r5 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                  @index += match_len
                 else
-                  terminal_parse_failure("NAPTR")
+                  terminal_parse_failure('"NAPTR"')
                   r5 = nil
                 end
                 s0 << r5
@@ -1582,7 +1615,7 @@ module DNS
         if node_cache[:ns_record].has_key?(index)
           cached = node_cache[:ns_record][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:ns_record][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -1601,11 +1634,11 @@ module DNS
               r4 = _nt_klass
               s0 << r4
               if r4
-                if has_terminal?("NS", false, index)
-                  r5 = instantiate_node(SyntaxNode,input, index...(index + 2))
-                  @index += 2
+                if (match_len = has_terminal?("NS", false, index))
+                  r5 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                  @index += match_len
                 else
-                  terminal_parse_failure("NS")
+                  terminal_parse_failure('"NS"')
                   r5 = nil
                 end
                 s0 << r5
@@ -1672,7 +1705,7 @@ module DNS
         if node_cache[:ptr_record].has_key?(index)
           cached = node_cache[:ptr_record][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:ptr_record][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -1691,11 +1724,11 @@ module DNS
               r4 = _nt_klass
               s0 << r4
               if r4
-                if has_terminal?("PTR", false, index)
-                  r5 = instantiate_node(SyntaxNode,input, index...(index + 3))
-                  @index += 3
+                if (match_len = has_terminal?("PTR", false, index))
+                  r5 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                  @index += match_len
                 else
-                  terminal_parse_failure("PTR")
+                  terminal_parse_failure('"PTR"')
                   r5 = nil
                 end
                 s0 << r5
@@ -1778,7 +1811,7 @@ module DNS
         if node_cache[:soa_record].has_key?(index)
           cached = node_cache[:soa_record][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:soa_record][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -1797,11 +1830,11 @@ module DNS
               r4 = _nt_klass
               s0 << r4
               if r4
-                if has_terminal?("SOA", false, index)
-                  r5 = instantiate_node(SyntaxNode,input, index...(index + 3))
-                  @index += 3
+                if (match_len = has_terminal?("SOA", false, index))
+                  r5 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                  @index += match_len
                 else
-                  terminal_parse_failure("SOA")
+                  terminal_parse_failure('"SOA"')
                   r5 = nil
                 end
                 s0 << r5
@@ -2050,7 +2083,7 @@ module DNS
         if node_cache[:srv_record].has_key?(index)
           cached = node_cache[:srv_record][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:srv_record][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -2070,11 +2103,11 @@ module DNS
               r5 = _nt_klass
               s1 << r5
               if r5
-                if has_terminal?("SRV", false, index)
-                  r6 = instantiate_node(SyntaxNode,input, index...(index + 3))
-                  @index += 3
+                if (match_len = has_terminal?("SRV", false, index))
+                  r6 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                  @index += match_len
                 else
-                  terminal_parse_failure("SRV")
+                  terminal_parse_failure('"SRV"')
                   r6 = nil
                 end
                 s1 << r6
@@ -2122,6 +2155,7 @@ module DNS
           r1 = nil
         end
         if r1
+          r1 = SyntaxNode.new(input, (index-1)...index) if r1 == true
           r0 = r1
           r0.extend(SrvRecord4)
         else
@@ -2138,11 +2172,11 @@ module DNS
                 r19 = _nt_ttl
                 s15 << r19
                 if r19
-                  if has_terminal?("SRV", false, index)
-                    r20 = instantiate_node(SyntaxNode,input, index...(index + 3))
-                    @index += 3
+                  if (match_len = has_terminal?("SRV", false, index))
+                    r20 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                    @index += match_len
                   else
-                    terminal_parse_failure("SRV")
+                    terminal_parse_failure('"SRV"')
                     r20 = nil
                   end
                   s15 << r20
@@ -2190,6 +2224,7 @@ module DNS
             r15 = nil
           end
           if r15
+            r15 = SyntaxNode.new(input, (index-1)...index) if r15 == true
             r0 = r15
             r0.extend(SrvRecord4)
           else
@@ -2203,11 +2238,11 @@ module DNS
                 r32 = _nt_ttl
                 s29 << r32
                 if r32
-                  if has_terminal?("SRV", false, index)
-                    r33 = instantiate_node(SyntaxNode,input, index...(index + 3))
-                    @index += 3
+                  if (match_len = has_terminal?("SRV", false, index))
+                    r33 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                    @index += match_len
                   else
-                    terminal_parse_failure("SRV")
+                    terminal_parse_failure('"SRV"')
                     r33 = nil
                   end
                   s29 << r33
@@ -2254,6 +2289,7 @@ module DNS
               r29 = nil
             end
             if r29
+              r29 = SyntaxNode.new(input, (index-1)...index) if r29 == true
               r0 = r29
               r0.extend(SrvRecord4)
             else
@@ -2267,11 +2303,11 @@ module DNS
                   r45 = _nt_klass
                   s42 << r45
                   if r45
-                    if has_terminal?("SRV", false, index)
-                      r46 = instantiate_node(SyntaxNode,input, index...(index + 3))
-                      @index += 3
+                    if (match_len = has_terminal?("SRV", false, index))
+                      r46 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                      @index += match_len
                     else
-                      terminal_parse_failure("SRV")
+                      terminal_parse_failure('"SRV"')
                       r46 = nil
                     end
                     s42 << r46
@@ -2318,6 +2354,7 @@ module DNS
                 r42 = nil
               end
               if r42
+                r42 = SyntaxNode.new(input, (index-1)...index) if r42 == true
                 r0 = r42
                 r0.extend(SrvRecord4)
               else
@@ -2370,7 +2407,7 @@ module DNS
         if node_cache[:spf_record].has_key?(index)
           cached = node_cache[:spf_record][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:spf_record][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -2389,11 +2426,11 @@ module DNS
               r4 = _nt_klass
               s0 << r4
               if r4
-                if has_terminal?("SPF", false, index)
-                  r5 = instantiate_node(SyntaxNode,input, index...(index + 3))
-                  @index += 3
+                if (match_len = has_terminal?("SPF", false, index))
+                  r5 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                  @index += match_len
                 else
-                  terminal_parse_failure("SPF")
+                  terminal_parse_failure('"SPF"')
                   r5 = nil
                 end
                 s0 << r5
@@ -2460,7 +2497,7 @@ module DNS
         if node_cache[:txt_record].has_key?(index)
           cached = node_cache[:txt_record][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:txt_record][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -2479,11 +2516,11 @@ module DNS
               r4 = _nt_klass
               s0 << r4
               if r4
-                if has_terminal?("TXT", false, index)
-                  r5 = instantiate_node(SyntaxNode,input, index...(index + 3))
-                  @index += 3
+                if (match_len = has_terminal?("TXT", false, index))
+                  r5 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+                  @index += match_len
                 else
-                  terminal_parse_failure("TXT")
+                  terminal_parse_failure('"TXT"')
                   r5 = nil
                 end
                 s0 << r5
@@ -2531,7 +2568,7 @@ module DNS
         if node_cache[:origin].has_key?(index)
           cached = node_cache[:origin][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:origin][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -2578,7 +2615,7 @@ module DNS
         if node_cache[:space].has_key?(index)
           cached = node_cache[:space][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:space][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -2586,10 +2623,11 @@ module DNS
 
         s0, i0 = [], index
         loop do
-          if has_terminal?('\G[ \\t]', true, index)
+          if has_terminal?(@regexps[gr = '\A[ \\t]'] ||= Regexp.new(gr), :regexp, index)
             r1 = true
             @index += 1
           else
+            terminal_parse_failure('[ \\t]')
             r1 = nil
           end
           if r1
@@ -2622,7 +2660,7 @@ module DNS
         if node_cache[:linebreak].has_key?(index)
           cached = node_cache[:linebreak][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:linebreak][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -2630,10 +2668,11 @@ module DNS
 
         s0, i0 = [], index
         loop do
-          if has_terminal?('\G[\\n\\r]', true, index)
+          if has_terminal?(@regexps[gr = '\A[\\n\\r]'] ||= Regexp.new(gr), :regexp, index)
             r1 = true
             @index += 1
           else
+            terminal_parse_failure('[\\n\\r]')
             r1 = nil
           end
           if r1
@@ -2666,7 +2705,7 @@ module DNS
         if node_cache[:space_or_break].has_key?(index)
           cached = node_cache[:space_or_break][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:space_or_break][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -2674,10 +2713,11 @@ module DNS
 
         s0, i0 = [], index
         loop do
-          if has_terminal?('\G[\\s]', true, index)
+          if has_terminal?(@regexps[gr = '\A[\\s]'] ||= Regexp.new(gr), :regexp, index)
             r1 = true
             @index += 1
           else
+            terminal_parse_failure('[\\s]')
             r1 = nil
           end
           if r1
@@ -2716,7 +2756,7 @@ module DNS
         if node_cache[:klass].has_key?(index)
           cached = node_cache[:klass][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:klass][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -2724,11 +2764,11 @@ module DNS
 
         i0 = index
         i1, s1 = index, []
-        if has_terminal?("IN", false, index)
-          r2 = instantiate_node(SyntaxNode,input, index...(index + 2))
-          @index += 2
+        if (match_len = has_terminal?("IN", false, index))
+          r2 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+          @index += match_len
         else
-          terminal_parse_failure("IN")
+          terminal_parse_failure('"IN"')
           r2 = nil
         end
         s1 << r2
@@ -2744,17 +2784,19 @@ module DNS
           r1 = nil
         end
         if r1
+          r1 = SyntaxNode.new(input, (index-1)...index) if r1 == true
           r0 = r1
           r0.extend(Klass1)
         else
-          if has_terminal?('', false, index)
-            r4 = instantiate_node(SyntaxNode,input, index...(index + 0))
-            @index += 0
+          if (match_len = has_terminal?('', false, index))
+            r4 = true
+            @index += match_len
           else
-            terminal_parse_failure('')
+            terminal_parse_failure('\'\'')
             r4 = nil
           end
           if r4
+            r4 = SyntaxNode.new(input, (index-1)...index) if r4 == true
             r0 = r4
             r0.extend(Klass1)
           else
@@ -2782,7 +2824,7 @@ module DNS
         if node_cache[:comment].has_key?(index)
           cached = node_cache[:comment][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:comment][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -2801,21 +2843,22 @@ module DNS
         r1 = instantiate_node(SyntaxNode,input, i1...index, s1)
         s0 << r1
         if r1
-          if has_terminal?(";", false, index)
-            r3 = instantiate_node(SyntaxNode,input, index...(index + 1))
-            @index += 1
+          if (match_len = has_terminal?(";", false, index))
+            r3 = true
+            @index += match_len
           else
-            terminal_parse_failure(";")
+            terminal_parse_failure('";"')
             r3 = nil
           end
           s0 << r3
           if r3
             s4, i4 = [], index
             loop do
-              if has_terminal?('\G[^\\n\\r]', true, index)
+              if has_terminal?(@regexps[gr = '\A[^\\n\\r]'] ||= Regexp.new(gr), :regexp, index)
                 r5 = true
                 @index += 1
               else
+                terminal_parse_failure('[^\\n\\r]')
                 r5 = nil
               end
               if r5
@@ -2860,7 +2903,7 @@ module DNS
         if node_cache[:ns].has_key?(index)
           cached = node_cache[:ns][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:ns][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -2910,7 +2953,7 @@ module DNS
         if node_cache[:rp].has_key?(index)
           cached = node_cache[:rp][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:rp][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -2922,23 +2965,26 @@ module DNS
           s2, i2 = [], index
           loop do
             i3 = index
-            if has_terminal?("\\.", false, index)
-              r4 = instantiate_node(SyntaxNode,input, index...(index + 2))
-              @index += 2
+            if (match_len = has_terminal?("\\.", false, index))
+              r4 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+              @index += match_len
             else
-              terminal_parse_failure("\\.")
+              terminal_parse_failure('"\\\\."')
               r4 = nil
             end
             if r4
+              r4 = SyntaxNode.new(input, (index-1)...index) if r4 == true
               r3 = r4
             else
-              if has_terminal?('\G[+a-zA-Z0-9\\-)]', true, index)
+              if has_terminal?(@regexps[gr = '\A[+a-zA-Z0-9\\-)]'] ||= Regexp.new(gr), :regexp, index)
                 r5 = true
                 @index += 1
               else
+                terminal_parse_failure('[+a-zA-Z0-9\\-)]')
                 r5 = nil
               end
               if r5
+                r5 = SyntaxNode.new(input, (index-1)...index) if r5 == true
                 r3 = r5
               else
                 @index = i3
@@ -2959,11 +3005,11 @@ module DNS
           end
           s1 << r2
           if r2
-            if has_terminal?(".", false, index)
-              r6 = instantiate_node(SyntaxNode,input, index...(index + 1))
-              @index += 1
+            if (match_len = has_terminal?(".", false, index))
+              r6 = true
+              @index += match_len
             else
-              terminal_parse_failure(".")
+              terminal_parse_failure('"."')
               r6 = nil
             end
             s1 << r6
@@ -3015,7 +3061,7 @@ module DNS
         if node_cache[:serial].has_key?(index)
           cached = node_cache[:serial][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:serial][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -3076,7 +3122,7 @@ module DNS
         if node_cache[:time_interval].has_key?(index)
           cached = node_cache[:time_interval][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:time_interval][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -3124,7 +3170,7 @@ module DNS
         if node_cache[:refresh].has_key?(index)
           cached = node_cache[:refresh][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:refresh][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -3174,7 +3220,7 @@ module DNS
         if node_cache[:integer].has_key?(index)
           cached = node_cache[:integer][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:integer][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -3182,10 +3228,11 @@ module DNS
 
         s0, i0 = [], index
         loop do
-          if has_terminal?('\G[0-9]', true, index)
+          if has_terminal?(@regexps[gr = '\A[0-9]'] ||= Regexp.new(gr), :regexp, index)
             r1 = true
             @index += 1
           else
+            terminal_parse_failure('[0-9]')
             r1 = nil
           end
           if r1
@@ -3228,131 +3275,142 @@ module DNS
         if node_cache[:time_multiplier].has_key?(index)
           cached = node_cache[:time_multiplier][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:time_multiplier][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
         end
 
         i0 = index
-        if has_terminal?('s', false, index)
-          r1 = instantiate_node(SyntaxNode,input, index...(index + 1))
-          @index += 1
+        if (match_len = has_terminal?('s', false, index))
+          r1 = true
+          @index += match_len
         else
-          terminal_parse_failure('s')
+          terminal_parse_failure('\'s\'')
           r1 = nil
         end
         if r1
+          r1 = SyntaxNode.new(input, (index-1)...index) if r1 == true
           r0 = r1
           r0.extend(TimeMultiplier0)
         else
-          if has_terminal?('S', false, index)
-            r2 = instantiate_node(SyntaxNode,input, index...(index + 1))
-            @index += 1
+          if (match_len = has_terminal?('S', false, index))
+            r2 = true
+            @index += match_len
           else
-            terminal_parse_failure('S')
+            terminal_parse_failure('\'S\'')
             r2 = nil
           end
           if r2
+            r2 = SyntaxNode.new(input, (index-1)...index) if r2 == true
             r0 = r2
             r0.extend(TimeMultiplier0)
           else
-            if has_terminal?('m', false, index)
-              r3 = instantiate_node(SyntaxNode,input, index...(index + 1))
-              @index += 1
+            if (match_len = has_terminal?('m', false, index))
+              r3 = true
+              @index += match_len
             else
-              terminal_parse_failure('m')
+              terminal_parse_failure('\'m\'')
               r3 = nil
             end
             if r3
+              r3 = SyntaxNode.new(input, (index-1)...index) if r3 == true
               r0 = r3
               r0.extend(TimeMultiplier0)
             else
-              if has_terminal?('M', false, index)
-                r4 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                @index += 1
+              if (match_len = has_terminal?('M', false, index))
+                r4 = true
+                @index += match_len
               else
-                terminal_parse_failure('M')
+                terminal_parse_failure('\'M\'')
                 r4 = nil
               end
               if r4
+                r4 = SyntaxNode.new(input, (index-1)...index) if r4 == true
                 r0 = r4
                 r0.extend(TimeMultiplier0)
               else
-                if has_terminal?('h', false, index)
-                  r5 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                  @index += 1
+                if (match_len = has_terminal?('h', false, index))
+                  r5 = true
+                  @index += match_len
                 else
-                  terminal_parse_failure('h')
+                  terminal_parse_failure('\'h\'')
                   r5 = nil
                 end
                 if r5
+                  r5 = SyntaxNode.new(input, (index-1)...index) if r5 == true
                   r0 = r5
                   r0.extend(TimeMultiplier0)
                 else
-                  if has_terminal?('H', false, index)
-                    r6 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                    @index += 1
+                  if (match_len = has_terminal?('H', false, index))
+                    r6 = true
+                    @index += match_len
                   else
-                    terminal_parse_failure('H')
+                    terminal_parse_failure('\'H\'')
                     r6 = nil
                   end
                   if r6
+                    r6 = SyntaxNode.new(input, (index-1)...index) if r6 == true
                     r0 = r6
                     r0.extend(TimeMultiplier0)
                   else
-                    if has_terminal?('d', false, index)
-                      r7 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                      @index += 1
+                    if (match_len = has_terminal?('d', false, index))
+                      r7 = true
+                      @index += match_len
                     else
-                      terminal_parse_failure('d')
+                      terminal_parse_failure('\'d\'')
                       r7 = nil
                     end
                     if r7
+                      r7 = SyntaxNode.new(input, (index-1)...index) if r7 == true
                       r0 = r7
                       r0.extend(TimeMultiplier0)
                     else
-                      if has_terminal?('D', false, index)
-                        r8 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                        @index += 1
+                      if (match_len = has_terminal?('D', false, index))
+                        r8 = true
+                        @index += match_len
                       else
-                        terminal_parse_failure('D')
+                        terminal_parse_failure('\'D\'')
                         r8 = nil
                       end
                       if r8
+                        r8 = SyntaxNode.new(input, (index-1)...index) if r8 == true
                         r0 = r8
                         r0.extend(TimeMultiplier0)
                       else
-                        if has_terminal?('w', false, index)
-                          r9 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                          @index += 1
+                        if (match_len = has_terminal?('w', false, index))
+                          r9 = true
+                          @index += match_len
                         else
-                          terminal_parse_failure('w')
+                          terminal_parse_failure('\'w\'')
                           r9 = nil
                         end
                         if r9
+                          r9 = SyntaxNode.new(input, (index-1)...index) if r9 == true
                           r0 = r9
                           r0.extend(TimeMultiplier0)
                         else
-                          if has_terminal?('W', false, index)
-                            r10 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                            @index += 1
+                          if (match_len = has_terminal?('W', false, index))
+                            r10 = true
+                            @index += match_len
                           else
-                            terminal_parse_failure('W')
+                            terminal_parse_failure('\'W\'')
                             r10 = nil
                           end
                           if r10
+                            r10 = SyntaxNode.new(input, (index-1)...index) if r10 == true
                             r0 = r10
                             r0.extend(TimeMultiplier0)
                           else
-                            if has_terminal?('', false, index)
-                              r11 = instantiate_node(SyntaxNode,input, index...(index + 0))
-                              @index += 0
+                            if (match_len = has_terminal?('', false, index))
+                              r11 = true
+                              @index += match_len
                             else
-                              terminal_parse_failure('')
+                              terminal_parse_failure('\'\'')
                               r11 = nil
                             end
                             if r11
+                              r11 = SyntaxNode.new(input, (index-1)...index) if r11 == true
                               r0 = r11
                               r0.extend(TimeMultiplier0)
                             else
@@ -3396,7 +3454,7 @@ module DNS
         if node_cache[:reretry].has_key?(index)
           cached = node_cache[:reretry][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:reretry][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -3453,7 +3511,7 @@ module DNS
         if node_cache[:expiry].has_key?(index)
           cached = node_cache[:expiry][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:expiry][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -3510,7 +3568,7 @@ module DNS
         if node_cache[:nxttl].has_key?(index)
           cached = node_cache[:nxttl][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:nxttl][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -3570,7 +3628,7 @@ module DNS
         if node_cache[:ttl].has_key?(index)
           cached = node_cache[:ttl][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:ttl][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -3592,17 +3650,19 @@ module DNS
           r1 = nil
         end
         if r1
+          r1 = SyntaxNode.new(input, (index-1)...index) if r1 == true
           r0 = r1
           r0.extend(Ttl1)
         else
-          if has_terminal?('', false, index)
-            r4 = instantiate_node(SyntaxNode,input, index...(index + 0))
-            @index += 0
+          if (match_len = has_terminal?('', false, index))
+            r4 = true
+            @index += match_len
           else
-            terminal_parse_failure('')
+            terminal_parse_failure('\'\'')
             r4 = nil
           end
           if r4
+            r4 = SyntaxNode.new(input, (index-1)...index) if r4 == true
             r0 = r4
             r0.extend(Ttl1)
           else
@@ -3634,7 +3694,7 @@ module DNS
         if node_cache[:host].has_key?(index)
           cached = node_cache[:host][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:host][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -3643,10 +3703,11 @@ module DNS
         i0 = index
         s1, i1 = [], index
         loop do
-          if has_terminal?('\G[*a-zA-Z0-9\\-\\._]', true, index)
+          if has_terminal?(@regexps[gr = '\A[*a-zA-Z0-9\\-\\._]'] ||= Regexp.new(gr), :regexp, index)
             r2 = true
             @index += 1
           else
+            terminal_parse_failure('[*a-zA-Z0-9\\-\\._]')
             r2 = nil
           end
           if r2
@@ -3662,39 +3723,43 @@ module DNS
           r1 = instantiate_node(SyntaxNode,input, i1...index, s1)
         end
         if r1
+          r1 = SyntaxNode.new(input, (index-1)...index) if r1 == true
           r0 = r1
           r0.extend(Host0)
         else
-          if has_terminal?("@", false, index)
-            r3 = instantiate_node(SyntaxNode,input, index...(index + 1))
-            @index += 1
+          if (match_len = has_terminal?("@", false, index))
+            r3 = true
+            @index += match_len
           else
-            terminal_parse_failure("@")
+            terminal_parse_failure('"@"')
             r3 = nil
           end
           if r3
+            r3 = SyntaxNode.new(input, (index-1)...index) if r3 == true
             r0 = r3
             r0.extend(Host0)
           else
-            if has_terminal?(' ', false, index)
-              r4 = instantiate_node(SyntaxNode,input, index...(index + 1))
-              @index += 1
+            if (match_len = has_terminal?(' ', false, index))
+              r4 = true
+              @index += match_len
             else
-              terminal_parse_failure(' ')
+              terminal_parse_failure('\' \'')
               r4 = nil
             end
             if r4
+              r4 = SyntaxNode.new(input, (index-1)...index) if r4 == true
               r0 = r4
               r0.extend(Host0)
             else
-              if has_terminal?("\t", false, index)
-                r5 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                @index += 1
+              if (match_len = has_terminal?("\t", false, index))
+                r5 = true
+                @index += match_len
               else
-                terminal_parse_failure("\t")
+                terminal_parse_failure('"\\t"')
                 r5 = nil
               end
               if r5
+                r5 = SyntaxNode.new(input, (index-1)...index) if r5 == true
                 r0 = r5
                 r0.extend(Host0)
               else
@@ -3721,7 +3786,7 @@ module DNS
         if node_cache[:data].has_key?(index)
           cached = node_cache[:data][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:data][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
@@ -3729,10 +3794,11 @@ module DNS
 
         s0, i0 = [], index
         loop do
-          if has_terminal?('\G[^;\\n\\r]', true, index)
+          if has_terminal?(@regexps[gr = '\A[^;\\n\\r]'] ||= Regexp.new(gr), :regexp, index)
             r1 = true
             @index += 1
           else
+            terminal_parse_failure('[^;\\n\\r]')
             r1 = nil
           end
           if r1
@@ -3755,22 +3821,23 @@ module DNS
       end
 
       module TxtData0
+        def space
+          elements[0]
+        end
+
+        def txt_data
+          elements[1]
+        end
       end
 
       module TxtData1
-      end
-
-      module TxtData2
-        def space
+        def txt_string
           elements[0]
         end
 
       end
 
-      module TxtData3
-      end
-
-      module TxtData4
+      module TxtData2
         def to_s
           text_value
         end
@@ -3781,217 +3848,227 @@ module DNS
         if node_cache[:txt_data].has_key?(index)
           cached = node_cache[:txt_data][index]
           if cached
-            cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            node_cache[:txt_data][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
             @index = cached.interval.end
           end
           return cached
         end
 
         i0, s0 = index, []
-        if has_terminal?('"', false, index)
-          r2 = instantiate_node(SyntaxNode,input, index...(index + 1))
-          @index += 1
-        else
-          terminal_parse_failure('"')
-          r2 = nil
-        end
-        if r2
-          r1 = r2
-        else
-          r1 = instantiate_node(SyntaxNode,input, index...index)
-        end
+        r1 = _nt_txt_string
         s0 << r1
         if r1
-          s3, i3 = [], index
+          s2, i2 = [], index
           loop do
-            i4 = index
-            if has_terminal?('\\"', false, index)
-              r5 = instantiate_node(SyntaxNode,input, index...(index + 2))
-              @index += 2
-            else
-              terminal_parse_failure('\\"')
-              r5 = nil
-            end
-            if r5
-              r4 = r5
-            else
-              i6, s6 = index, []
-              i7 = index
-              if has_terminal?('"', false, index)
-                r8 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                @index += 1
-              else
-                terminal_parse_failure('"')
-                r8 = nil
-              end
-              if r8
-                r7 = nil
-              else
-                @index = i7
-                r7 = instantiate_node(SyntaxNode,input, index...index)
-              end
-              s6 << r7
-              if r7
-                if has_terminal?('\G[^\\n\\r]', true, index)
-                  r9 = true
-                  @index += 1
-                else
-                  r9 = nil
-                end
-                s6 << r9
-              end
-              if s6.last
-                r6 = instantiate_node(SyntaxNode,input, i6...index, s6)
-                r6.extend(TxtData0)
-              else
-                @index = i6
-                r6 = nil
-              end
-              if r6
-                r4 = r6
-              else
-                @index = i4
-                r4 = nil
-              end
-            end
+            i3, s3 = index, []
+            r4 = _nt_space
+            s3 << r4
             if r4
-              s3 << r4
+              r5 = _nt_txt_data
+              s3 << r5
+            end
+            if s3.last
+              r3 = instantiate_node(SyntaxNode,input, i3...index, s3)
+              r3.extend(TxtData0)
+            else
+              @index = i3
+              r3 = nil
+            end
+            if r3
+              s2 << r3
             else
               break
             end
           end
-          r3 = instantiate_node(SyntaxNode,input, i3...index, s3)
-          s0 << r3
-          if r3
-            if has_terminal?('"', false, index)
-              r11 = instantiate_node(SyntaxNode,input, index...(index + 1))
-              @index += 1
-            else
-              terminal_parse_failure('"')
-              r11 = nil
-            end
-            if r11
-              r10 = r11
-            else
-              r10 = instantiate_node(SyntaxNode,input, index...index)
-            end
-            s0 << r10
-            if r10
-              s12, i12 = [], index
-              loop do
-                i13, s13 = index, []
-                r14 = _nt_space
-                s13 << r14
-                if r14
-                  if has_terminal?('"', false, index)
-                    r15 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                    @index += 1
-                  else
-                    terminal_parse_failure('"')
-                    r15 = nil
-                  end
-                  s13 << r15
-                  if r15
-                    s16, i16 = [], index
-                    loop do
-                      i17 = index
-                      if has_terminal?('\\"', false, index)
-                        r18 = instantiate_node(SyntaxNode,input, index...(index + 2))
-                        @index += 2
-                      else
-                        terminal_parse_failure('\\"')
-                        r18 = nil
-                      end
-                      if r18
-                        r17 = r18
-                      else
-                        i19, s19 = index, []
-                        i20 = index
-                        if has_terminal?('"', false, index)
-                          r21 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                          @index += 1
-                        else
-                          terminal_parse_failure('"')
-                          r21 = nil
-                        end
-                        if r21
-                          r20 = nil
-                        else
-                          @index = i20
-                          r20 = instantiate_node(SyntaxNode,input, index...index)
-                        end
-                        s19 << r20
-                        if r20
-                          if has_terminal?('\G[^\\n\\r]', true, index)
-                            r22 = true
-                            @index += 1
-                          else
-                            r22 = nil
-                          end
-                          s19 << r22
-                        end
-                        if s19.last
-                          r19 = instantiate_node(SyntaxNode,input, i19...index, s19)
-                          r19.extend(TxtData1)
-                        else
-                          @index = i19
-                          r19 = nil
-                        end
-                        if r19
-                          r17 = r19
-                        else
-                          @index = i17
-                          r17 = nil
-                        end
-                      end
-                      if r17
-                        s16 << r17
-                      else
-                        break
-                      end
-                    end
-                    r16 = instantiate_node(SyntaxNode,input, i16...index, s16)
-                    s13 << r16
-                    if r16
-                      if has_terminal?('"', false, index)
-                        r23 = instantiate_node(SyntaxNode,input, index...(index + 1))
-                        @index += 1
-                      else
-                        terminal_parse_failure('"')
-                        r23 = nil
-                      end
-                      s13 << r23
-                    end
-                  end
-                end
-                if s13.last
-                  r13 = instantiate_node(SyntaxNode,input, i13...index, s13)
-                  r13.extend(TxtData2)
-                else
-                  @index = i13
-                  r13 = nil
-                end
-                if r13
-                  s12 << r13
-                else
-                  break
-                end
-              end
-              r12 = instantiate_node(SyntaxNode,input, i12...index, s12)
-              s0 << r12
-            end
-          end
+          r2 = instantiate_node(SyntaxNode,input, i2...index, s2)
+          s0 << r2
         end
         if s0.last
           r0 = instantiate_node(SyntaxNode,input, i0...index, s0)
-          r0.extend(TxtData3)
-          r0.extend(TxtData4)
+          r0.extend(TxtData1)
+          r0.extend(TxtData2)
         else
           @index = i0
           r0 = nil
         end
 
         node_cache[:txt_data][start_index] = r0
+
+        r0
+      end
+
+      module TxtString0
+        def to_s
+          text_value
+        end
+      end
+
+      def _nt_txt_string
+        start_index = index
+        if node_cache[:txt_string].has_key?(index)
+          cached = node_cache[:txt_string][index]
+          if cached
+            node_cache[:txt_string][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            @index = cached.interval.end
+          end
+          return cached
+        end
+
+        i0 = index
+        r1 = _nt_quoted_string
+        if r1
+          r1 = SyntaxNode.new(input, (index-1)...index) if r1 == true
+          r0 = r1
+          r0.extend(TxtString0)
+        else
+          r2 = _nt_unquoted_string
+          if r2
+            r2 = SyntaxNode.new(input, (index-1)...index) if r2 == true
+            r0 = r2
+            r0.extend(TxtString0)
+          else
+            @index = i0
+            r0 = nil
+          end
+        end
+
+        node_cache[:txt_string][start_index] = r0
+
+        r0
+      end
+
+      module QuotedString0
+      end
+
+      module QuotedString1
+        def to_s
+          text_value
+        end
+      end
+
+      def _nt_quoted_string
+        start_index = index
+        if node_cache[:quoted_string].has_key?(index)
+          cached = node_cache[:quoted_string][index]
+          if cached
+            node_cache[:quoted_string][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            @index = cached.interval.end
+          end
+          return cached
+        end
+
+        i0, s0 = index, []
+        if (match_len = has_terminal?('"', false, index))
+          r1 = true
+          @index += match_len
+        else
+          terminal_parse_failure('\'"\'')
+          r1 = nil
+        end
+        s0 << r1
+        if r1
+          s2, i2 = [], index
+          loop do
+            i3 = index
+            if (match_len = has_terminal?('\"', false, index))
+              r4 = instantiate_node(SyntaxNode,input, index...(index + match_len))
+              @index += match_len
+            else
+              terminal_parse_failure('\'\\"\'')
+              r4 = nil
+            end
+            if r4
+              r4 = SyntaxNode.new(input, (index-1)...index) if r4 == true
+              r3 = r4
+            else
+              if has_terminal?(@regexps[gr = '\A[^"]'] ||= Regexp.new(gr), :regexp, index)
+                r5 = true
+                @index += 1
+              else
+                terminal_parse_failure('[^"]')
+                r5 = nil
+              end
+              if r5
+                r5 = SyntaxNode.new(input, (index-1)...index) if r5 == true
+                r3 = r5
+              else
+                @index = i3
+                r3 = nil
+              end
+            end
+            if r3
+              s2 << r3
+            else
+              break
+            end
+          end
+          r2 = instantiate_node(SyntaxNode,input, i2...index, s2)
+          s0 << r2
+          if r2
+            if (match_len = has_terminal?('"', false, index))
+              r6 = true
+              @index += match_len
+            else
+              terminal_parse_failure('\'"\'')
+              r6 = nil
+            end
+            s0 << r6
+          end
+        end
+        if s0.last
+          r0 = instantiate_node(SyntaxNode,input, i0...index, s0)
+          r0.extend(QuotedString0)
+        else
+          @index = i0
+          r0 = nil
+        end
+
+        node_cache[:quoted_string][start_index] = r0
+
+        r0
+      end
+
+      module UnquotedString0
+        def to_s
+          text_value
+        end
+      end
+
+      def _nt_unquoted_string
+        start_index = index
+        if node_cache[:unquoted_string].has_key?(index)
+          cached = node_cache[:unquoted_string][index]
+          if cached
+            node_cache[:unquoted_string][index] = cached = SyntaxNode.new(input, index...(index + 1)) if cached == true
+            @index = cached.interval.end
+          end
+          return cached
+        end
+
+        s0, i0 = [], index
+        loop do
+          if has_terminal?(@regexps[gr = '\A[a-zA-Z0-9]'] ||= Regexp.new(gr), :regexp, index)
+            r1 = true
+            @index += 1
+          else
+            terminal_parse_failure('[a-zA-Z0-9]')
+            r1 = nil
+          end
+          if r1
+            s0 << r1
+          else
+            break
+          end
+        end
+        if s0.empty?
+          @index = i0
+          r0 = nil
+        else
+          r0 = instantiate_node(SyntaxNode,input, i0...index, s0)
+          r0.extend(UnquotedString0)
+        end
+
+        node_cache[:unquoted_string][start_index] = r0
 
         r0
       end

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -69,6 +69,11 @@ _domainkey    TXT   "v=DKIM1\\;g=*\\;k=rsa\\; p=4tkw1bbkfa0ahfjgnbewr2ttkvahvfmf
 @             TXT   "some other \\"message\\" goes here" ; embedded quotes
 long          TXT   "a multi-segment TXT record" "usually used for really long TXT records" "since each segment can only span 255 chars"
 unquoted      TXT   some text data
+
+multiline     TXT   "A TXT record
+split across multiple lines
+with LF and CRLF line endings"
+
 @             SPF   "v=spf1 a a:other.domain.com ~all"
 
 45        IN   PTR   @
@@ -127,7 +132,7 @@ ZONE
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      zone.rr.size.should be(43)
+      zone.rr.size.should be(44)
     end
 
     it "should build the correct NS records" do
@@ -308,7 +313,7 @@ ZONE
     it "should build the correct TXT records" do
       zone = DNS::Zonefile.load(@zonefile)
       txt_records = zone.records_of DNS::Zonefile::TXT
-      txt_records.size.should be(4)
+      txt_records.size.should be(5)
 
       txt_records.detect { |r|
         r.host == "_domainkey.example.com." && r.data == '"v=DKIM1\;g=*\;k=rsa\; p=4tkw1bbkfa0ahfjgnbewr2ttkvahvfmfizowl9s4g0h28io76ndow25snl9iumpcv0jwxr2k"'
@@ -324,6 +329,10 @@ ZONE
 
       txt_records.detect { |r|
         r.host == "unquoted.example.com." && r.data == 'some text data'
+      }.should_not be_nil
+
+      txt_records.detect { |r|
+        r.host == "multiline.example.com." && r.data == "\"A TXT record\nsplit across multiple lines\nwith LF and CRLF line endings\""
       }.should_not be_nil
     end
 


### PR DESCRIPTION
Currently if any newline characters are found in a TXT field the parser will fail. This small change allows quoted strings to contain newline characters whilst keeping the previous functionality the same.