### PR TITLE
Rework host post-processing for @ replacement and origin

### DIFF
--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -436,14 +436,7 @@ grammar Zonefile
   rule host
     ( ([*a-zA-Z0-9\-\._]+) / "@" / ' ' / "\t" ) {
       def to_s
-        case text_value
-        when /\.$/
-          text_value
-        when "@", /\s/
-          text_value
-        else
-          text_value + '.@'
-        end
+        text_value
       end
     }
   end

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -432,4 +432,29 @@ ZONE
       expect(soa.responsible_party).to eql('.')
     end
   end
+
+  describe "parsing an ORIGIN of ." do
+    before do
+      @zonefile =<<-ZONE
+      ; Hi! I'm an example zonefile.
+; $ORIGIN .
+$TTL 86400; expire in 1 day.
+example.com   IN  SOA  ns.example.com. hostmaster.example.com. (
+              2007120710 ; serial number of this zone file
+              1d         ; refresh (1 day)
+              1d         ; retry time in case of a problem (1 day)
+              4W         ; expiration time (4 weeks)
+              3600       ; minimum caching time in case of failed lookups (1 hour)
+              )
+example.com            A     10.1.0.1
+ZONE
+    end
+
+    it "should parse the zone correctly" do
+      zone = DNS::Zonefile.load(@zonefile)
+      a_record = zone.records_of(DNS::Zonefile::A).first
+      expect(a_record.host).to eq("example.com.")
+    end
+  end
+
 end


### PR DESCRIPTION
Move host qualifying (@ and last host processing) into zonefile.rb and out of the grammar.

Replace class eval'd methods for qualifying host names with a single private method on Record.

This also fixes an issue when ORIGIN was set to "."