### PR TITLE
Allow the = character in unquoted TXT content

### DIFF
--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -505,7 +505,7 @@ grammar Zonefile
   end
 
   rule unquoted_string
-    [a-zA-Z0-9]+ {
+    [a-zA-Z0-9=]+ {
       def to_s
         text_value
       end

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -73,6 +73,7 @@ with_ms_txt   TXT   ( "Some text" )
 @             TXT   "some other \\"message\\" goes here" ; embedded quotes
 long          TXT   "a multi-segment TXT record" "usually used for really long TXT records" "since each segment can only span 255 chars"
 unquoted      TXT   some text data
+with-eq       TXT   MX=example
 
 multiline     TXT   "A TXT record
 split across multiple lines
@@ -142,7 +143,7 @@ ZONE
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(50)
+      expect(zone.rr.size).to eq(51)
     end
 
     it "should build the correct NS records" do
@@ -350,7 +351,7 @@ ZONE
     it "should build the correct TXT records" do
       zone = DNS::Zonefile.load(@zonefile)
       txt_records = zone.records_of DNS::Zonefile::TXT
-      expect(txt_records.size).to eq(6)
+      expect(txt_records.size).to eq(7)
 
       expect(txt_records.detect { |r|
         r.host == "_domainkey.example.com." && r.data == '"v=DKIM1\;g=*\;k=rsa\; p=4tkw1bbkfa0ahfjgnbewr2ttkvahvfmfizowl9s4g0h28io76ndow25snl9iumpcv0jwxr2k"'
@@ -370,6 +371,10 @@ ZONE
 
       expect(txt_records.detect { |r|
         r.host == "unquoted.example.com." && r.data == 'some text data'
+      }).to_not be_nil
+
+      expect(txt_records.detect { |r|
+        r.host == "with-eq.example.com." && r.data == 'MX=example'
       }).to_not be_nil
 
       expect(txt_records.detect { |r|

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -73,7 +73,7 @@ with_ms_txt   TXT   ( "Some text" )
 @             TXT   "some other \\"message\\" goes here" ; embedded quotes
 long          TXT   "a multi-segment TXT record" "usually used for really long TXT records" "since each segment can only span 255 chars"
 unquoted      TXT   some text data
-with-eq       TXT   MX=example
+with-eq       TXT   MS=example
 
 multiline     TXT   "A TXT record
 split across multiple lines
@@ -374,7 +374,7 @@ ZONE
       }).to_not be_nil
 
       expect(txt_records.detect { |r|
-        r.host == "with-eq.example.com." && r.data == 'MX=example'
+        r.host == "with-eq.example.com." && r.data == 'MS=example'
       }).to_not be_nil
 
       expect(txt_records.detect { |r|


### PR DESCRIPTION
This is a short-term solution for `MS=xxx`content in TXT records.

There is a larger problem which is that TXT records should allow any ASCII characters. Simply changing the regex to allow \x20-\x7F (i.e. printable ASCII) results in problems parsing TXT values produced by Microsoft, so I am still investigating a broader fix, however I wanted to get this bugfix out sooner rather than later.
