### PR TITLE
Bugfix/underscore in txt content

### DIFF
--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -505,7 +505,7 @@ grammar Zonefile
   end
 
   rule unquoted_string
-    [a-zA-Z0-9=]+ {
+    [a-zA-Z0-9=_]+ {
       def to_s
         text_value
       end

--- a/lib/dns/zonefile/version.rb
+++ b/lib/dns/zonefile/version.rb
@@ -1,5 +1,5 @@
 module DNS
   module Zonefile
-    VERSION = "1.1.4"
+    VERSION = "1.1.5"
   end
 end

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -79,6 +79,8 @@ multiline     TXT   "A TXT record
 split across multiple lines
 with LF and CRLF line endings"
 
+with-underscore TXT abc_123
+
 ; Microsoft AD DNS Examples with Aging.
 with-age [AGE:999992222] 60     A   10.0.0.7             ; with a specified AGE
 with-age-aaaa [AGE:999992222] 60     AAAA   10.0.0.8             ; with a specified AGE
@@ -143,7 +145,7 @@ ZONE
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(51)
+      expect(zone.rr.size).to eq(52)
     end
 
     it "should build the correct NS records" do
@@ -351,7 +353,7 @@ ZONE
     it "should build the correct TXT records" do
       zone = DNS::Zonefile.load(@zonefile)
       txt_records = zone.records_of DNS::Zonefile::TXT
-      expect(txt_records.size).to eq(7)
+      expect(txt_records.size).to eq(8)
 
       expect(txt_records.detect { |r|
         r.host == "_domainkey.example.com." && r.data == '"v=DKIM1\;g=*\;k=rsa\; p=4tkw1bbkfa0ahfjgnbewr2ttkvahvfmfizowl9s4g0h28io76ndow25snl9iumpcv0jwxr2k"'


### PR DESCRIPTION
Allows underscore to be used in TXT record content.

Ideally the content would allow any non-whitespace character in unquoted TXT record content, however there are currently issues getting this to work with the MS-specific record data.