### PR TITLE
allow colon in unescaped character sequences

### DIFF
--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -505,7 +505,7 @@ grammar Zonefile
   end
 
   rule unquoted_string
-    [a-zA-Z0-9=_]+ {
+    [a-zA-Z0-9=_:]+ {
       def to_s
         text_value
       end

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -80,6 +80,7 @@ split across multiple lines
 with LF and CRLF line endings"
 
 with-underscore TXT abc_123
+with-colon TXT abc:123
 
 ; Microsoft AD DNS Examples with Aging.
 with-age [AGE:999992222] 60     A   10.0.0.7             ; with a specified AGE
@@ -145,7 +146,7 @@ ZONE
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(52)
+      expect(zone.rr.size).to eq(53)
     end
 
     it "should build the correct NS records" do
@@ -353,7 +354,7 @@ ZONE
     it "should build the correct TXT records" do
       zone = DNS::Zonefile.load(@zonefile)
       txt_records = zone.records_of DNS::Zonefile::TXT
-      expect(txt_records.size).to eq(8)
+      expect(txt_records.size).to eq(9)
 
       expect(txt_records.detect { |r|
         r.host == "_domainkey.example.com." && r.data == '"v=DKIM1\;g=*\;k=rsa\; p=4tkw1bbkfa0ahfjgnbewr2ttkvahvfmfizowl9s4g0h28io76ndow25snl9iumpcv0jwxr2k"'


### PR DESCRIPTION
I am not 100% sure if this is correct as I was not able to find the corresponding section about unescaped character sequences with spaces in the RFCs.