### PR TITLE
Add CAA record support

### DIFF
--- a/lib/dns/zonefile.rb
+++ b/lib/dns/zonefile.rb
@@ -44,6 +44,7 @@ module DNS
 	    case e.record_type
 	    when 'A'      then @records << A.new(@vars, e)
 	    when 'AAAA'   then @records << AAAA.new(@vars, e)
+            when 'CAA'    then @records << CAA.new(@vars, e)
 	    when 'CNAME'  then @records << CNAME.new(@vars, e)
 	    when 'MX'     then @records << MX.new(@vars, e)
 	    when 'NAPTR'  then @records << NAPTR.new(@vars, e)
@@ -148,6 +149,23 @@ module DNS
     end
 
     class AAAA < A
+    end
+
+    class CAA < Record
+      attr_accessor :host, :flags, :tag, :value
+
+      def initialize(vars, zonefile_record)
+        @vars = vars
+        if zonefile_record
+          self.host = qualify_host(zonefile_record.host.to_s)
+          @vars[:last_host] = self.host
+          self.ttl          = zonefile_record.ttl.to_i
+	  self.klass        = zonefile_record.klass.to_s
+          self.flags        = zonefile_record.flags.to_i
+          self.tag          = zonefile_record.tag.to_s
+          self.value        = zonefile_record.value.to_s
+        end
+      end
     end
 
     class CNAME < Record

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -53,7 +53,7 @@ grammar Zonefile
   end
 
   rule resource_record
-    record:(a_record / aaaa_record / cname_record / mx_record / naptr_record / ns_record / ptr_record / srv_record / spf_record / sshfp_record / txt_record / soa_record) space* comment? linebreak {
+    record:(a_record / aaaa_record / caa_record / cname_record / mx_record / naptr_record / ns_record / ptr_record / srv_record / spf_record / sshfp_record / txt_record / soa_record) space* comment? linebreak {
       def zone
         p = parent
         while p.respond_to?(:parent) && p.parent
@@ -124,6 +124,20 @@ grammar Zonefile
     [\da-fA-F:.] 2..39 {
       def to_s
         text_value.downcase
+      end
+    }
+  end
+
+  rule caa_record
+    (
+      host space ms_age ttl klass "CAA" space flags:integer space tag:unquoted_string space value:quoted_string
+    ) {
+      def to_s
+        "#{host} #{ttl} #{klass} CAA #{flags} #{tag} #{value}"
+      end
+
+      def record_type
+        "CAA"
       end
     }
   end

--- a/lib/dns/zonefile.treetop
+++ b/lib/dns/zonefile.treetop
@@ -130,7 +130,7 @@ grammar Zonefile
 
   rule caa_record
     (
-      host space ms_age ttl klass "CAA" space flags:integer space tag:unquoted_string space value:quoted_string
+      host space ms_age ttl klass "CAA" space flags:integer space tag:unquoted_string space value:caa_value
     ) {
       def to_s
         "#{host} #{ttl} #{klass} CAA #{flags} #{tag} #{value}"
@@ -138,6 +138,14 @@ grammar Zonefile
 
       def record_type
         "CAA"
+      end
+    }
+  end
+
+  rule caa_value
+    (quoted_string / unquoted_string) {
+      def to_s
+        text_value
       end
     }
   end

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -82,6 +82,8 @@ with LF and CRLF line endings"
 with-underscore TXT abc_123
 
 @             CAA   0 issue "letsencrypt.org"
+issuewild     CAA   0 issuewild "comodoca.com"
+iodef         CAA   0 iodef "mailto:example@example.com"
 
 ; Microsoft AD DNS Examples with Aging.
 with-age [AGE:999992222] 60     A   10.0.0.7             ; with a specified AGE
@@ -147,7 +149,7 @@ ZONE
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(53)
+      expect(zone.rr.size).to eq(55)
     end
 
     it "should build the correct NS records" do
@@ -225,12 +227,19 @@ ZONE
     it "should build the correct CAA records" do
       zone = DNS::Zonefile.load(@zonefile)
       caa_records = zone.records_of DNS::Zonefile::CAA
-      expect(caa_records.size).to eq(1)
+      expect(caa_records.size).to eq(3)
 
       expect(caa_records.detect { |caa|
         caa.host == "example.com." && caa.flags == 0 && caa.tag == "issue" && caa.value == "\"letsencrypt.org\""
       }).to_not be_nil
 
+      expect(caa_records.detect { |caa|
+        caa.host == "issuewild.example.com." && caa.flags == 0 && caa.tag == "issuewild" && caa.value == "\"comodoca.com\""
+      }).to_not be_nil
+
+      expect(caa_records.detect { |caa|
+        caa.host == "iodef.example.com." && caa.flags == 0 && caa.tag == "iodef" && caa.value == "\"mailto:example@example.com\""
+      }).to_not be_nil
     end
 
     it "should build the correct CNAME records" do

--- a/spec/dns/zonefile_spec.rb
+++ b/spec/dns/zonefile_spec.rb
@@ -81,6 +81,8 @@ with LF and CRLF line endings"
 
 with-underscore TXT abc_123
 
+@             CAA   0 issue "letsencrypt.org"
+
 ; Microsoft AD DNS Examples with Aging.
 with-age [AGE:999992222] 60     A   10.0.0.7             ; with a specified AGE
 with-age-aaaa [AGE:999992222] 60     AAAA   10.0.0.8             ; with a specified AGE
@@ -145,7 +147,7 @@ ZONE
 
     it "should build the correct number of resource records" do
       zone = DNS::Zonefile.parse(@zonefile)
-      expect(zone.rr.size).to eq(52)
+      expect(zone.rr.size).to eq(53)
     end
 
     it "should build the correct NS records" do
@@ -218,6 +220,17 @@ ZONE
       expect(a_records.detect { |a|
         a.host == "www.test.example.com." && a.address == "10.1.0.2" && a.ttl == 3600
       }).to_not be_nil
+    end
+
+    it "should build the correct CAA records" do
+      zone = DNS::Zonefile.load(@zonefile)
+      caa_records = zone.records_of DNS::Zonefile::CAA
+      expect(caa_records.size).to eq(1)
+
+      expect(caa_records.detect { |caa|
+        caa.host == "example.com." && caa.flags == 0 && caa.tag == "issue" && caa.value == "\"letsencrypt.org\""
+      }).to_not be_nil
+
     end
 
     it "should build the correct CNAME records" do


### PR DESCRIPTION
Adds basic CAA record support. This iteration does not remove the quotes around the value in the CAA record.