### PR TITLE
Drop unused, outdated CircleCI configuration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,0 @@
-dependencies:
-  pre:
-    - gem install bundler --version 1.11
-machine:
-  ruby:
-    version: 2.3.0


### PR DESCRIPTION
This PR drops an unused file for CircleCI config (of an old format).